### PR TITLE
Create custom course search and filter view

### DIFF
--- a/classes/output/core/course_renderer.php
+++ b/classes/output/core/course_renderer.php
@@ -28,6 +28,7 @@ use html_writer;
 use coursecat_helper;
 use stdClass;
 use core_course_list_element;
+use core_course_category;
 use theme_govbrds\util\course;
 use moodle_url;
 
@@ -39,6 +40,143 @@ use moodle_url;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class course_renderer extends \core_course_renderer {
+    /**
+     * Renders the course catalogue page with flat course list and search/filter bar.
+     *
+     * Overrides the core method to avoid the redirect to management.php and to display
+     * all courses as a flat card list instead of a category tree.
+     *
+     * @param int|stdClass|core_course_category $category
+     * @return string
+     */
+    public function course_category($category) {
+        global $CFG;
+
+        if (empty($category)) {
+            $coursecat = core_course_category::user_top();
+        } else if (is_object($category) && $category instanceof core_course_category) {
+            $coursecat = $category;
+        } else {
+            $coursecat = core_course_category::get(is_object($category) ? $category->id : $category);
+        }
+
+        $search  = optional_param('search', '', PARAM_TEXT);
+        $page    = optional_param('page', 0, PARAM_INT);
+        $perpage = max(1, (int) ($CFG->coursesperpage ?: 20));
+
+        $catfilter = (int) $coursecat->id;
+
+        // Build category options for the filter dropdown.
+        $allcats = core_course_category::make_categories_list();
+        $categoryoptions = [];
+        foreach ($allcats as $catid => $catname) {
+            $categoryoptions[] = [
+                'id'       => $catid,
+                'name'     => $catname,
+                'selected' => ($catid === $catfilter),
+            ];
+        }
+
+        $hasactivefilter = !empty($search) || !empty($catfilter);
+        [$courses, $totalcount] = $this->get_catalogue_courses($search, $catfilter, $page, $perpage);
+
+        $paginationparams = [];
+        if (!empty($search)) {
+            $paginationparams['search'] = $search;
+        }
+        if (!empty($catfilter)) {
+            $paginationparams['categoryid'] = $catfilter;
+        }
+
+        $chelper = new coursecat_helper();
+        $chelper->set_show_courses(self::COURSECAT_SHOW_COURSES_EXPANDED)
+                ->set_courses_display_options([
+                    'limit'         => $perpage,
+                    'offset'        => $page * $perpage,
+                    'paginationurl' => new moodle_url('/course/index.php', $paginationparams),
+                ])
+                ->set_attributes(['class' => 'course-catalogue-list']);
+
+        $formaction = (new moodle_url('/course/index.php'))->out(false);
+
+        $output = $this->render_from_template('theme_govbrds/course_catalogue_filters', [
+            'formaction'           => $formaction,
+            'search'               => $search,
+            'categoryid'           => $catfilter,
+            'allcategoriesselected'=> empty($catfilter),
+            'categories'           => $categoryoptions,
+            'hasactivefilter'      => $hasactivefilter,
+            'totalcount'           => $totalcount,
+        ]);
+
+        if (!$totalcount) {
+            $msg = !empty($search)
+                ? get_string('nocoursesfound', '', $search)
+                : get_string('nocoursesyet');
+            $output .= html_writer::div($msg, 'alert alert-info mt-3');
+        } else {
+            $output .= $this->coursecat_courses($chelper, $courses, $totalcount);
+        }
+
+        return $output;
+    }
+
+    /**
+     * Fetches courses for the catalogue applying optional name and category filters.
+     *
+     * Uses a direct DB query so that search and category (with subcategories) can be
+     * combined without the pagination distortion that post-filtering would cause.
+     *
+     * @param string $search     Partial name to search (empty = no filter)
+     * @param int    $catfilter  Category ID to restrict to (0 = all categories)
+     * @param int    $page       Zero-based page index
+     * @param int    $perpage    Records per page
+     * @return array [core_course_list_element[], int $totalcount]
+     */
+    private function get_catalogue_courses(string $search, int $catfilter, int $page, int $perpage): array {
+        global $DB;
+
+        $conditions = ['c.id <> :siteid', 'c.visible = 1'];
+        $params     = ['siteid' => SITEID];
+        $joins      = '';
+
+        if (!empty($catfilter)) {
+            $catrecord = $DB->get_record('course_categories', ['id' => $catfilter], 'id, path');
+            if ($catrecord) {
+                $joins .= ' JOIN {course_categories} cc ON c.category = cc.id';
+                $conditions[] = '(cc.id = :catid OR ' . $DB->sql_like('cc.path', ':catpath') . ')';
+                $params['catid']   = $catfilter;
+                $params['catpath'] = $catrecord->path . '/%';
+            }
+        }
+
+        if (!empty($search)) {
+            $escaped = '%' . $DB->sql_like_escape($search) . '%';
+            $conditions[] = '(' . $DB->sql_like('c.fullname', ':fsearch', false)
+                          . ' OR ' . $DB->sql_like('c.shortname', ':ssearch', false) . ')';
+            $params['fsearch'] = $escaped;
+            $params['ssearch'] = $escaped;
+        }
+
+        $where = implode(' AND ', $conditions);
+        $base  = "FROM {course} c{$joins} WHERE {$where}";
+
+        $totalcount = (int) $DB->count_records_sql("SELECT COUNT(DISTINCT c.id) {$base}", $params);
+        $records    = $DB->get_records_sql(
+            "SELECT DISTINCT c.* {$base} ORDER BY c.fullname ASC",
+            $params,
+            $page * $perpage,
+            $perpage
+        );
+
+        $courses = [];
+        foreach ($records as $record) {
+            $courses[$record->id] = new core_course_list_element($record);
+        }
+
+        return [$courses, $totalcount];
+    }
+
     /**
      * Returns HTML to print tree of course categories (with number of courses) for the frontpage
      *

--- a/cli/create_courses_test.php
+++ b/cli/create_courses_test.php
@@ -1,4 +1,4 @@
--<?php
+<?php
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -16,7 +16,9 @@
 
 /**
  * CLI script to create test courses in Moodle.
- * This script creates multiple courses to test the infinite scroll feature.
+ *
+ * Cria categorias na raiz (parent=0) para cada disciplina e
+ * distribui os cursos nelas.
  *
  * Use:
  * php create_courses_test.php --quantity=50
@@ -32,79 +34,41 @@ require_once(__DIR__ . '/../../../config.php');
 require_once($CFG->libdir . '/clilib.php');
 require_once($CFG->dirroot . '/course/lib.php');
 
-// Get command-line parameters.
 [$options, $unrecognized] = cli_get_params(
     [
-        'help' => false,
+        'help'     => false,
         'quantity' => 50,
-        'category' => 1,
-        'prefix' => 'Test Course ',
+        'prefix'   => 'Curso Teste ',
     ],
     [
         'h' => 'help',
         'q' => 'quantity',
-        'c' => 'category',
         'p' => 'prefix',
     ]
 );
 
 if ($options['help']) {
-    echo "Script for creating test courses in Moodle.
+    echo "Script para criação de cursos de teste no Moodle.
 
-Use:
+Cria categorias na raiz (parent=0) por disciplina e distribui os cursos nelas.
+Categorias já existentes são reutilizadas.
+
+Uso:
     php create_courses_test.php [options]
 
-Options:
-    -h, --help              Display this help message.
-    -q, --quantity=NUMBER   Number of courses to create (default: 50)
-    -c, --category=ID       Category ID where courses are to be created (default: 1)
-    -p, --prefix=TEXT       Course name prefix (default: 'Test Course')
+Opções:
+    -h, --help              Exibe esta mensagem de ajuda.
+    -q, --quantity=NUMBER   Número de cursos a criar (padrão: 50)
+    -p, --prefix=TEXT       Prefixo do nome do curso (padrão: 'Curso Teste')
 
-Examples:
-    php create_test_courses.php --quantity=100
-    php create_test_courses.php --quantity=30 --category=2 --prefix='Course Demo'
+Exemplos:
+    php create_courses_test.php --quantity=100
+    php create_courses_test.php --quantity=30 --prefix='Demo'
 
 ";
     exit(0);
 }
 
-// Validate quantity.
-$quantity = (int)$options['quantity'];
-if ($quantity < 1 || $quantity > 1000) {
-    cli_error("The quantity must be between 1 and 1000.");
-}
-
-// Validate category.
-$categoryid = (int)$options['category'];
-try {
-    $category = core_course_category::get($categoryid);
-} catch (Exception $e) {
-    cli_error("Category with ID {$categoryid} not found");
-}
-
-$prefix = $options['prefix'];
-
-echo "========================================\n";
-echo "Criador de Cursos de Teste - Moodle\n";
-echo "========================================\n";
-echo "Quantidade: {$quantity} cursos\n";
-echo "Categoria: {$category->name} (ID: {$categoryid})\n";
-echo "Prefixo: {$prefix}\n";
-echo "========================================\n\n";
-
-// Confirm execution.
-echo "Deseja continuar? (s/n): ";
-$handle = fopen("php://stdin", "r");
-$line = fgets($handle);
-if (trim($line) != 's' && trim($line) != 'S') {
-    echo "Operação cancelada.\n";
-    exit(0);
-}
-fclose($handle);
-
-echo "\nIniciando criação de cursos...\n\n";
-
-// Arrays for varying names and descriptions.
 $subjects = [
     'Matemática', 'Física', 'Química', 'Biologia', 'História',
     'Geografia', 'Português', 'Inglês', 'Programação', 'Design',
@@ -121,45 +85,88 @@ $themes = [
     'Digital', 'Contemporânea', 'Experimental', 'Avançada', 'Fundamental',
 ];
 
-$created = 0;
-$errors = 0;
+$quantity = (int)$options['quantity'];
+if ($quantity < 1 || $quantity > 1000) {
+    cli_error("A quantidade deve estar entre 1 e 1000.");
+}
+
+$prefix = $options['prefix'];
+
+echo "========================================\n";
+echo "Criador de Cursos de Teste - Moodle\n";
+echo "========================================\n";
+echo "Quantidade : {$quantity} cursos\n";
+echo "Prefixo    : {$prefix}\n";
+echo "Categorias : criadas/reutilizadas na raiz (parent=0)\n";
+echo "========================================\n\n";
+
+echo "Deseja continuar? (s/n): ";
+$handle = fopen("php://stdin", "r");
+$line   = fgets($handle);
+fclose($handle);
+if (strtolower(trim($line)) !== 's') {
+    echo "Operação cancelada.\n";
+    exit(0);
+}
+
+echo "\nVerificando/criando categorias na raiz...\n";
+
+// Create or reuse one root-level category per subject.
+$categorymap = []; // subject => category id
+foreach ($subjects as $subject) {
+    $existing = $DB->get_record('course_categories', ['name' => $subject, 'parent' => 0]);
+    if ($existing) {
+        $categorymap[$subject] = (int)$existing->id;
+        echo "  Existente: {$subject} (ID: {$existing->id})\n";
+    } else {
+        $catdata           = new stdClass();
+        $catdata->name     = $subject;
+        $catdata->parent   = 0;
+        $catdata->idnumber = 'testcat_' . strtolower(preg_replace('/[^a-z0-9]/i', '_', $subject));
+        $newcat = core_course_category::create($catdata);
+        $categorymap[$subject] = (int)$newcat->id;
+        echo "  Criada   : {$subject} (ID: {$newcat->id})\n";
+    }
+}
+
+echo "\nIniciando criação de cursos...\n\n";
+
+$created  = 0;
+$errors   = 0;
+$catcount = [];
 
 for ($i = 1; $i <= $quantity; $i++) {
     try {
-        // Generate a unique name for the course.
         $subject = $subjects[array_rand($subjects)];
-        $level = $levels[array_rand($levels)];
-        $theme = $themes[array_rand($themes)];
+        $level   = $levels[array_rand($levels)];
+        $theme   = $themes[array_rand($themes)];
 
-        $coursename = "{$prefix} {$i}: {$subject} {$level}";
-        $shortname = "test_" . strtolower(str_replace(' ', '_', $subject)) . "_{$i}_" . time();
+        $categoryid = $categorymap[$subject];
+        $coursename = "{$prefix}{$i}: {$subject} {$level}";
+        $shortname  = 'test_' . strtolower(preg_replace('/[^a-z0-9]/i', '_', $subject)) . "_{$i}_" . time();
 
-        // Prepare course data.
-        $coursedata = new stdClass();
-        $coursedata->fullname = $coursename;
-        $coursedata->shortname = $shortname;
-        $coursedata->category = $categoryid;
-        $coursedata->category = $categoryid;
-        $coursedata->summary = "Este é um curso de teste criado automaticamente para testar o scroll infinito. "
-                             . "Curso de {$subject} {$theme} nível {$level}. "
-                             . "Conteúdo: Este curso aborda os principais conceitos e práticas relacionados a {$subject}, "
-                             . "com foco em aplicações práticas e teoria {$theme}.";
+        $coursedata                = new stdClass();
+        $coursedata->fullname      = $coursename;
+        $coursedata->shortname     = $shortname;
+        $coursedata->category      = $categoryid;
+        $coursedata->summary       = "Curso de teste criado automaticamente. "
+                                   . "Disciplina: {$subject} {$theme}, nível {$level}. "
+                                   . "Aborda conceitos e práticas relacionados a {$subject} com foco em aplicações {$theme}.";
         $coursedata->summaryformat = FORMAT_HTML;
-        $coursedata->format = 'topics';
-        $coursedata->numsections = 5;
-        $coursedata->startdate = time();
-        $coursedata->enddate = time() + (90 * 24 * 60 * 60); // 90 dias
-        $coursedata->visible = 1;
-        $coursedata->showgrades = 1;
-        $coursedata->newsitems = 5;
-        $coursedata->lang = 'pt_br';
+        $coursedata->format        = 'topics';
+        $coursedata->numsections   = 5;
+        $coursedata->startdate     = time();
+        $coursedata->enddate       = time() + (90 * 24 * 60 * 60);
+        $coursedata->visible       = 1;
+        $coursedata->showgrades    = 1;
+        $coursedata->newsitems     = 5;
+        $coursedata->lang          = 'pt_br';
 
-        // Create the course.
-        $course = create_course($coursedata);
+        create_course($coursedata);
         $created++;
+        $catcount[$categoryid] = ($catcount[$categoryid] ?? 0) + 1;
 
-        // Show progress.
-        if ($i % 10 == 0) {
+        if ($i % 10 === 0) {
             echo "Progresso: {$i}/{$quantity} cursos criados\n";
         }
     } catch (Exception $e) {
@@ -171,12 +178,16 @@ for ($i = 1; $i <= $quantity; $i++) {
 echo "\n========================================\n";
 echo "Processo finalizado!\n";
 echo "========================================\n";
-echo "Cursos criados com sucesso: {$created}\n";
-echo "Erros: {$errors}\n";
+echo "Cursos criados: {$created}\n";
+echo "Erros         : {$errors}\n";
 echo "========================================\n";
 
 if ($created > 0) {
-    echo "\nOs cursos foram criados na categoria: {$category->name}\n";
-    echo "Você pode visualizá-los em: {$CFG->wwwroot}/course/index.php?categoryid={$categoryid}\n";
+    echo "\nDistribuição por categoria:\n";
+    foreach ($catcount as $catid => $count) {
+        $cat = core_course_category::get($catid);
+        echo "  {$cat->name} (ID:{$catid}): {$count} curso(s)\n";
+    }
 }
+
 exit(0);

--- a/cli/delete_courses_test.php
+++ b/cli/delete_courses_test.php
@@ -164,6 +164,48 @@ echo "Courses successfully deleted: {$deleted}\n";
 echo "Errors: {$errors}\n";
 echo "========================================\n";
 
+// Delete test categories (idnumber LIKE 'testcat_%') that are now empty.
+$catsql = "SELECT id, name, idnumber, coursecount
+             FROM {course_categories}
+            WHERE " . $DB->sql_like('idnumber', ':idnumber') . "
+              AND coursecount = 0";
+
+$catparams = ['idnumber' => 'testcat_%'];
+
+if ($categoryid !== null) {
+    $catsql .= " AND parent = :parent";
+    $catparams['parent'] = (int)$categoryid;
+}
+
+$catsql .= " ORDER BY id ASC";
+
+$testcats = $DB->get_records_sql($catsql, $catparams);
+
+if (!empty($testcats)) {
+    echo "\nCategorias de teste vazias encontradas: " . count($testcats) . "\n";
+
+    $catdeleted = 0;
+    $caterrors  = 0;
+
+    foreach ($testcats as $cat) {
+        try {
+            $catobj = core_course_category::get($cat->id, IGNORE_MISSING);
+            if ($catobj) {
+                $catobj->delete_full(false);
+                $catdeleted++;
+            }
+        } catch (Exception $e) {
+            $caterrors++;
+            echo "ERRO ao deletar categoria [{$cat->id}] {$cat->name}: " . $e->getMessage() . "\n";
+        }
+    }
+
+    echo "Categorias deletadas: {$catdeleted}\n";
+    if ($caterrors > 0) {
+        echo "Erros ao deletar categorias: {$caterrors}\n";
+    }
+}
+
 // Clear cache.
 echo "\nClearing cache...\n";
 rebuild_course_cache(0, true);

--- a/lang/en/theme_govbrds.php
+++ b/lang/en/theme_govbrds.php
@@ -25,6 +25,9 @@
 defined("MOODLE_INTERNAL") || die();
 
 $string["about"] = "About";
+$string["catalogue_allcategories"] = "All categories";
+$string["catalogue_clearfilters"] = "Clear";
+$string["catalogue_resultcount"] = '{$a} course(s) found';
 $string["accessibility"] = "Accessibility";
 $string["address"] = "Address";
 $string["address_desc"] =

--- a/templates/course.mustache
+++ b/templates/course.mustache
@@ -90,7 +90,7 @@
         {{> theme_govbrds/header }}
 
         <main class="d-flex flex-fill mb-5" id="main">
-            <div class="container-lg d-flex">
+            <div class="container-lg">
                 <div class="row">
                 {{> theme_govbrds/navbar }}
 

--- a/templates/course_catalogue_filters.mustache
+++ b/templates/course_catalogue_filters.mustache
@@ -1,0 +1,90 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template theme_govbrds/course_catalogue_filters
+
+    Search and filter bar for the course catalogue page (/course/index.php).
+
+    Context variables:
+    * formaction  - URL for the form action (string)
+    * search      - Current search term (string)
+    * categoryid  - Currently selected category ID (int, 0 = all)
+    * categories  - Array of {id, name, selected} for the category dropdown
+
+    Example context (json):
+    {
+        "formaction": "/course/index.php",
+        "search": "python",
+        "categoryid": 3,
+        "categories": [
+            {"id": 1, "name": "Tecnologia", "selected": false},
+            {"id": 3, "name": "Tecnologia / Programação", "selected": true}
+        ]
+    }
+}}
+<div class="course-catalogue-filters card p-4 mb-4 border-0 bg-light">
+    <form action="{{formaction}}" method="get" class="row g-3 align-items-end">
+        <div class="col-12 col-md-4">
+            <label for="catalogue-search" class="form-label font-weight-bold">
+                {{#str}}searchcourses, core{{/str}}
+            </label><br />
+            <div class="input-group">
+                <input
+                    type="text"
+                    id="catalogue-search"
+                    name="search"
+                    class="form-control"
+                    placeholder="{{#str}}searchcourses, core{{/str}}"
+                    value="{{search}}"
+                    aria-label="{{#str}}searchcourses, core{{/str}}"
+                >
+            </div>
+        </div>
+        <div class="col-12 col-md-3">
+            <label for="catalogue-category" class="form-label font-weight-bold">
+                {{#str}}category, moodle{{/str}}
+            </label><br />
+            <select id="catalogue-category" name="categoryid" class="form-control custom-select">
+                <option value="0" {{#allcategoriesselected}}selected{{/allcategoriesselected}}>
+                    {{#str}}catalogue_allcategories, theme_govbrds{{/str}}
+                </option>
+                {{#categories}}
+                    <option value="{{id}}" {{#selected}}selected{{/selected}}>{{name}}</option>
+                {{/categories}}
+            </select>
+        </div>
+        <div class="col-6 col-md-3">
+            <button type="submit" class="btn btn-primary primary w-100" aria-label="{{#str}}search, moodle{{/str}}" title="{{#str}}search, moodle{{/str}}">
+                <i class="fas fa-search" aria-hidden="true"></i>&nbsp;
+                <span class="d-none d-md-inline">{{#str}}search, moodle{{/str}}</span>
+            </button>
+        </div>
+        {{#hasactivefilter}}
+        <div class="col-6 col-md-2">
+            <a href="{{formaction}}" class="btn btn-outline-secondary w-100" title="{{#str}}catalogue_clearfilters, theme_govbrds{{/str}}">
+                <i class="fas fa-times" aria-hidden="true"></i>
+                <span class="d-none d-md-inline">{{#str}}catalogue_clearfilters, theme_govbrds{{/str}}</span>
+            </a>
+        </div>
+        {{/hasactivefilter}}
+    </form>
+    {{#hasactivefilter}}
+    <div class="mt-2 text-muted small">
+        {{#str}}catalogue_resultcount, theme_govbrds, {{totalcount}}{{/str}}
+    </div>
+    {{/hasactivefilter}}
+</div>

--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@ defined("MOODLE_INTERNAL") || die();
 $plugin->component = "theme_govbrds";
 
 // This is the version of the plugin.
-$plugin->version = 2026050500;
+$plugin->version = 2026050701;
 
 // This is the named version.
-$plugin->release = "v2.21 alpha";
+$plugin->release = "v2.22 alpha";
 $plugin->maturity = MATURITY_ALPHA;
 
 // This is the version of Moodle this plugin requires.


### PR DESCRIPTION
The category action bar (`category_action_bar`) rendered a form that submitted to `management.php?search=`. We completely replaced the `course_category()` method in the theme renderer.

**Modified/created files**

`classes/output/core/course_renderer.php`

-   Added `use core_course_category`
-   New `course_category()` method — overrides core, does not call `category_action_bar`, adds the search form, and always renders a flat card list
-   New private `get_catalogue_courses()` method — custom SQL query with support for:
    -   Name filter (`LIKE` on `fullname` and `shortname`)
    -   Category filter with automatic recursion via the `path` field in the `course_categories` table
    -   Both combined with correct pagination

`templates/course_catalogue_filters.mustache`

-   GET form to `/course/index.php` with `search` field and `categoryid` select
-   "Clear" button appears only when a filter is active
-   Result counter shown when a filter is active

`lang/en/theme_govbrds.php`

-   `catalogue_allcategories` — "All categories"
-   `catalogue_clearfilters` — "Clear"
-   `catalogue_resultcount` — "{n} course(s) found"

`version.php` — bumped to `2026050701`

**How it works**

-   `/course/index.php` → flat list of all courses + form at the top
-   `/course/index.php?search=python` → filters by name
-   `/course/index.php?categoryid=5` → filters courses from category 5 and its subcategories
-   `/course/index.php?search=python&categoryid=5` → both combined

After deploying: go to **Administration → Development → Purge all caches** to ensure the new template and strings are loaded.

deixa o fromato em markdown

The category action bar (`category_action_bar`) rendered a form that submitted to `management.php?search=`. We completely replaced the `course_category()` method in the theme renderer.

---

## Modified/created files

### `classes/output/core/course_renderer.php`

-   Added `use core_course_category`
-   New `course_category()` method — overrides core, does not call `category_action_bar`, adds the search form, and always renders a flat card list
-   New private `get_catalogue_courses()` method — custom SQL query with support for:
    -   Name filter (`LIKE` on `fullname` and `shortname`)
    -   Category filter with automatic recursion via the `path` field in the `course_categories` table
    -   Both combined with correct pagination

### `templates/course_catalogue_filters.mustache`

-   GET form to `/course/index.php` with `search` field and `categoryid` select
-   "Clear" button appears only when a filter is active
-   Result counter shown when a filter is active

### `lang/en/theme_govbrds.php`

-   `catalogue_allcategories` — "All categories"
-   `catalogue_clearfilters` — "Clear"
-   `catalogue_resultcount` — "{n} course(s) found"

### `version.php`

-   Bumped to `2026050701`

---

## How it works

URL | Behavior -- | -- /course/index.php | Flat list of all courses + form at the top /course/index.php?search=python | Filters by name /course/index.php?categoryid=5 | Filters courses from category 5 and its subcategories /course/index.php?search=python&categoryid=5 | Both combined

> **After deploying:** go to **Administration → Development → Purge all caches** to ensure the new template and strings are loaded.